### PR TITLE
by default passing CMD_DURATION to prompt function

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ If your prompt don't work correctly, try changeing the configuration.
 
 Define variables inherited to prompt functions. Set `all` to pass all global variables.
 
-**Default:** `status SHLVL`
+**Default:** `status SHLVL CMD_DURATION`
 
 ### Variable: `async_prompt_functions`
 

--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -122,6 +122,7 @@ if status is-interactive
         else
             echo status
             echo SHLVL
+            echo CMD_DURATION
         end
     end
 


### PR DESCRIPTION
I use [starship](https://starship.rs/) which has a feature to show [command duration](https://starship.rs/config/#command-duration): 

![image](https://user-images.githubusercontent.com/932940/69819319-aa840200-11cc-11ea-8c51-b9f4441cc83a.png)

Whenever `fish-async-prompt` is used, the duration disappears:

![image](https://user-images.githubusercontent.com/932940/69819364-cf787500-11cc-11ea-97be-46af53aceac5.png)

That is because `CMD_DURATION` is not passed to the underlying prompt function. This PR passes it by default.