### PR TITLE
Add variables not to be modified for Fish 3.0.2

### DIFF
--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -77,10 +77,8 @@ if status is-interactive
         begin
             set st $argv[1]
             while read line
-                contains $line FISH_VERSION PWD _ history
-                and continue
-
                 switch "$line"
+                case FISH_VERSION PWD _ history 'fish_*' hostname version
                 case status
                     echo status $st
                 case SHLVL


### PR DESCRIPTION
#26

Ignore fish_pid, hostname and version newly.