### PR TITLE
Use correct temporary directory

### DIFF
--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -1,12 +1,7 @@
 status is-interactive
 or exit 0
 
-set -l xdg_runtime_dir "$XDG_RUNTIME_DIR"
-test -z "$xdg_runtime_dir"
-and set xdg_runtime_dir /tmp
-
-set -g __async_prompt_tmpdir "$xdg_runtime_dir/fish-async-prompt"
-mkdir -p $__async_prompt_tmpdir
+set -g __async_prompt_tmpdir (command mktemp -d)
 
 # Setup after the user defined prompt functions are loaded.
 function __async_prompt_setup_on_startup --on-event fish_prompt


### PR DESCRIPTION
`/tmp` is not standard on macOS, and is not accessible on Android applications like Termux (an application providing Unix environment). The best way to create a temporary file/directory is [using `mktemp`](https://unix.stackexchange.com/a/174818).