### PR TITLE
support fish vi mode and other on-variable changes

### DIFF
--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -20,7 +20,9 @@ function __async_prompt_setup_on_startup --on-event fish_prompt
     end
 end
 
-function __async_prompt_fire --on-event fish_prompt
+not set -q async_prompt_on_variable
+and set async_prompt_on_variable fish_bind_mode
+function __async_prompt_fire --on-event fish_prompt (for var in $async_prompt_on_variable; printf '%s\n' --on-variable $var; end)
     set st $status
 
     for func in (__async_prompt_config_functions)
@@ -43,6 +45,8 @@ function __async_prompt_spawn
         set st $argv[1]
         while read line
             switch "$line"
+                case 'fish_bind_mode'
+                  echo fish_bind_mode $fish_bind_mode
                 case FISH_VERSION PWD _ history 'fish_*' hostname version
                 case status
                     echo status $st
@@ -96,6 +100,7 @@ function __async_prompt_config_inherit_variables
         echo status
         echo SHLVL
         echo CMD_DURATION
+        echo fish_bind_mode
     end
 end
 


### PR DESCRIPTION
This PR closes #34 and #45 where it will repaint prompt when variable changes.

There's a variable `$async_prompt_on_variable` that controls which variable would fire the repaint function (by default it includes `fish_bind_mode`).

To fix #45, one can set
```fish
set -U async_prompt_on_variable fish_bind_mode PWD
```
to execute the async prompt when `$PWD` changes (I've tested and it does works).

**NOTE:** I wasn't sure why #34 mentioned that `--on-variable` does not work. It works when I'm testing on my fish.
```fish
$ fish --version
fish, version 3.1.2
```