### PR TITLE
Use universal variables instead of temp files

### DIFF
--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -195,7 +195,7 @@ function __async_prompt_repaint_prompt --on-signal (__async_prompt_config_intern
     commandline -f repaint >/dev/null 2>/dev/null
 end
 
-function __async_prompt_variable_cleanup --on-event fish_exit
+function __async_prompt_tmpdir_cleanup --on-event fish_exit
     set -l prefix (string replace $fish_pid '' $__async_prompt_var)
     set -l prompt_vars (set --show | string match -rg '^\$('"$prefix"'\d+_[a-z_]+):' | uniq)
     for var in $prompt_vars

--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -195,7 +195,7 @@ function __async_prompt_repaint_prompt --on-signal (__async_prompt_config_intern
     commandline -f repaint >/dev/null 2>/dev/null
 end
 
-function __async_prompt_tmpdir_cleanup --on-event fish_exit
+function __async_prompt_variable_cleanup --on-event fish_exit
     set -l prefix (string replace $fish_pid '' $__async_prompt_var)
     set -l prompt_vars (set --show | string match -rg '^\$('"$prefix"'\d+_[a-z_]+):' | uniq)
     for var in $prompt_vars


### PR DESCRIPTION
While setting up my prompt with fish_async_prompt I noticed that after adding multiple async functions it started getting noticable slow. After a bit of digging around I found that adding an additional async function adds around 80ms of execution time to `fish_prompt`:

```
# 1 async function configured in async_prompt_functions
$ time fish_prompt
________________________________________________________
Executed in   87.69 millis    fish           external
   usr time   62.95 millis  243.00 micros   62.71 millis
   sys time   21.77 millis  885.00 micros   20.89 millis

# 2 async functions configured in async_prompt_functions
$ time fish_prompt
________________________________________________________
Executed in  166.54 millis    fish           external
   usr time  123.61 millis    1.29 millis  122.32 millis
   sys time   41.11 millis    3.16 millis   37.94 millis

# 3 async functions configured in async_prompt_functions
$ time fish_prompt
________________________________________________________
Executed in   256.66 millis    fish           external
   usr time   186.53 millis   1.44 millis  185.08 millis
   sys time   64.06 millis    3.92 millis   60.14 millis
```

While having 1 function like this isn't really noticable as it is below 100ms, this starts adding up quickly and becomes really noticable, especially when the whole goal is to make the prompt faster with making it async.

I didn't dig deep enough to investigate why reading from temporary files make this process this slow, but quickly doing a proof of concept using universal variables instead showed a huge performance increase:

```
# 5 async functions configured in async_prompt_functions
$ time fish_prompt                                                                                                                                                                       
________________________________________________________
Executed in  292.00 micros    fish           external
   usr time  265.00 micros  265.00 micros    0.00 micros
   sys time   28.00 micros   28.00 micros    0.00 micros
```

I've only tested it on my local setup (MacOS 13.2.1, fish 3.7.1), so I can't comment if this has unintended side effects on other systems, but since this variable handling is part of the shell itself I would presume no.