### PR TITLE
Ensure proper use of builtin `rm` in tmpdir cleanup function

### DIFF
--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -197,5 +197,5 @@ function __async_prompt_repaint_prompt --on-signal (__async_prompt_config_intern
 end
 
 function __async_prompt_tmpdir_cleanup --on-event fish_exit
-    rm -rf "$__async_prompt_tmpdir"
+    command rm -rf "$__async_prompt_tmpdir"
 end


### PR DESCRIPTION
By specifing `command`, an external alias for `rm` (for example the [trash cli](https://github.com/andreafrancia/trash-cli)), will not be used. This conflict could previously result in the trash cli displaying a short message about where the trashed files have been stored on shell exit. 