### PR TITLE
Various improvements & refresh-prompt-on-cmd compatibility

### DIFF
--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -120,8 +120,7 @@ function __async_prompt_fire --on-event fish_prompt (for var in $async_prompt_on
         # The result is stored in the $prompt variable and then written to the
         # temporary file (replacing the loading indicator)..
         __async_prompt_config_inherit_variables | __async_prompt_last_pipestatus=$__async_prompt_last_pipestatus __async_prompt_spawn \
-            $func' | read -z prompt
-            echo -n $prompt >'$tmpfile
+            'if functions -q '$func'; '$func'; else; echo -n ""; end | read -z prompt; echo -n $prompt >'$tmpfile
     end
     __async_prompt_log "__async_prompt_fire" "Prompt fire complete"
 end

--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -3,11 +3,12 @@ status is-interactive
 or exit 0
 
 
-# Logs a message to the debug log file if `async_prompt_debug` is set to `1`.
+# Logs a message to the debug log file if `rpoc_debug_log_enable` is set to
+# `1`.
 function __async_prompt_log --argument-names func_name message
-    if test "$async_prompt_debug" = 1
+    if test "$async_prompt_debug_log_enable" = 1
         # Initialize debug log file in XDG cache dir or ~/.cache if not already done
-        if not set -q __async_prompt_debug_log
+        if not set -q async_prompt_debug_log_path
             set -l cache_dir
             if set -q XDG_CACHE_HOME
                 set cache_dir "$XDG_CACHE_HOME/fish"
@@ -15,10 +16,10 @@ function __async_prompt_log --argument-names func_name message
                 set cache_dir "$HOME/.cache/fish"
             end
             mkdir -p "$cache_dir"
-            set -g __async_prompt_debug_log "$cache_dir/async_prompt_debug.log"
+            set -g async_prompt_debug_log_path "$cache_dir/async_prompt_debug.log"
         end
 
-        echo (date "+%Y-%m-%d %H:%M:%S") "[$func_name]" "$message" >> $__async_prompt_debug_log
+        echo (date "+%Y-%m-%d %H:%M:%S") "[$func_name]" "$message" >> $async_prompt_debug_log_path
     end
 end
 

--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -48,6 +48,13 @@ function __async_prompt_setup_on_startup --on-event fish_prompt
 
     for func in (__async_prompt_config_functions)
         __async_prompt_log "__async_prompt_setup_on_startup" "Setting up function: $func"
+
+        # Backup the original fish prompt functions if they exist so that they
+        # can be used by other fish plugins, such as `refresh-prompt-on-cmd`.
+        functions -c $func '__async_prompt_orig_'$func
+
+        # Replace the fish_prompt functions with replacements that cat the
+        # sync and async prompts from the tmpdir
         function $func -V func
             test -e $__async_prompt_tmpdir'/'$fish_pid'_'$func
             and command cat $__async_prompt_tmpdir'/'$fish_pid'_'$func

--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -18,13 +18,11 @@ function __async_prompt_setup_on_startup --on-event fish_prompt
     end
 end
 
-function __async_prompt_keep_last_pipestatus
-    set -g __async_prompt_last_pipestatus $pipestatus
-end
-
 not set -q async_prompt_on_variable
 and set async_prompt_on_variable fish_bind_mode
 function __async_prompt_fire --on-event fish_prompt (for var in $async_prompt_on_variable; printf '%s\n' --on-variable $var; end)
+    set -l __async_prompt_last_pipestatus $pipestatus
+
     for func in (__async_prompt_config_functions)
         set -l tmpfile $__async_prompt_tmpdir'/'$fish_pid'_'$func
 
@@ -33,7 +31,7 @@ function __async_prompt_fire --on-event fish_prompt (for var in $async_prompt_on
             eval (string escape -- $func'_loading_indicator' "$last_prompt") >$tmpfile
         end
 
-        __async_prompt_config_inherit_variables | __async_prompt_spawn \
+        __async_prompt_config_inherit_variables | __async_prompt_last_pipestatus=$__async_prompt_last_pipestatus __async_prompt_spawn \
             $func' | read -z prompt
             echo -n $prompt >'$tmpfile
     end

--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -13,7 +13,7 @@ function __async_prompt_setup_on_startup --on-event fish_prompt
     for func in (__async_prompt_config_functions)
         function $func -V func
             test -e $__async_prompt_tmpdir'/'$fish_pid'_'$func
-            and cat $__async_prompt_tmpdir'/'$fish_pid'_'$func
+            and command cat $__async_prompt_tmpdir'/'$fish_pid'_'$func
         end
     end
 end
@@ -195,5 +195,5 @@ function __async_prompt_repaint_prompt --on-signal (__async_prompt_config_intern
 end
 
 function __async_prompt_tmpdir_cleanup --on-event fish_exit
-    rm -rf "$__async_prompt_tmpdir"
+    command rm -rf "$__async_prompt_tmpdir"
 end


### PR DESCRIPTION
Hi,

First of all, thank you so much for creating this plugin. It's absolutely amazing.

I recently created my own fish plugin that allows you to refresh your prompt when you enter a command so that the prompt before that command shows an accurate time.

And I designed it to work with your plugin since they are an excellent combination.

![refresh-prompt-on-cmd](https://github.com/user-attachments/assets/1976655b-cf17-48bd-ad14-0e6f5ba7768d)

You can find more info in the repo, including detailed instructions how to set up fish with starship, your plugin and my plugin:
https://github.com/infused-kim/fish-refresh-prompt-on-cmd?tab=readme-ov-file#12-usage

In the process I made a few improvements to fish-async-prompt:

## 1. Revert "Fix #69" because it prevented `$status` from being passed to the prompt correctly

The commit was meant to fix issue:
https://github.com/acomagu/fish-async-prompt/issues/69

But the comment from the OP shows that it didn’t fix it. But instead it broke the status variable forwarding.

## 2. Use command builtin for cat and rm to prevent alias interference

I have aliased `cat` to `bat`, which adds syntax highlighting and line numbers to cat, but since the `fish-async-prompt` calls cat, it adds those line numbers to the prompt.

Another user reported the same issue with rm in https://github.com/acomagu/fish-async-prompt/pull/84.

## 3. Added debug logging

To help me better understand the code, I added debug logging to the code that can be enabled with `set -g async_prompt_debug_log_enable 1`.

You can control the destination file with `set -g async_prompt_debug_log_path $HOME/.cache/fish/async_prompt_debug.log`.

## 4. Added detailed comments

To integrate `fish-async-prompt` with `fish-refresh-prompt-on-cmd` it was necessary to fully understand how your plugin works. So, I added detailed comments everywhere.

They may be a bit excessive, since this is my first fish project and I didn't understand a lot of things initially. But perhaps it would be useful and interesting to other people.

In fact, someone recently even asked how this plugin works on reddit:
https://www.reddit.com/r/fishshell/s/oGpik9HoVd

## 4. Backup the original `fish_prompt` and `fish_right_prompt` so that other plugins can still use them

Your plugin replaces the `fish_prompt` and `fish_right_prompt` functions in interactive shells, but for my plugin to work, I need access to the original functions.

It would be great if this could be integrated into your versions so that users of my plugin don't need to use my fork.

## 5. In background process check if function exists before running

Another feature that's necessary to add compatibility with my plugin.

## Conclusion

It would be amazing if you could add numbre 4. and 5. to your plugin and I would really appreciate it. I totally understand if you are not interested in adding the other stuff (or any of it... I know how hard it is to maintain an OS project).

Just let me know if you woud like any changes and I will update the PR.
