### PR TITLE
Trigger prompt update on PWD change (between prompts), i.e. alt+left/right

### DIFF
--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -23,7 +23,7 @@ function __async_prompt_keep_last_pipestatus
 end
 
 not set -q async_prompt_on_variable
-and set async_prompt_on_variable fish_bind_mode
+and set async_prompt_on_variable fish_bind_mode PWD
 function __async_prompt_fire --on-event fish_prompt (for var in $async_prompt_on_variable; printf '%s\n' --on-variable $var; end)
     for func in (__async_prompt_config_functions)
         set -l tmpfile $__async_prompt_tmpdir'/'$fish_pid'_'$func


### PR DESCRIPTION
Opening this as a place to host some discussion...

This fixes `PWD` (dir) changes between new prompts, i.e. when using `alt+left/right` or other bindings that alter `PWD` 

I am not sure this is the best approach but upon cursory review of the code and some testing, it seems like a good first step. Only issue is a double firing of `__async_prompt_fire` when using the `cd` command (submit command triggers prompt update and so does the `PWD` change). Could throttle updates, or cancel outstanding updates?