### PR TITLE
Fixup pipestatus and 23e416fdece9

### DIFF
--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -18,7 +18,8 @@ function __async_prompt_setup_on_startup --on-event fish_prompt
     end
 end
 
-function __async_prompt_keep_last_pipestatus
+set -g __async_prompt_last_pipestatus 0
+function __async_prompt_keep_last_pipestatus --on-event fish_postexec
     set -g __async_prompt_last_pipestatus $pipestatus
 end
 
@@ -157,6 +158,7 @@ function __async_prompt_config_inherit_variables
         echo SHLVL
         echo status
     end
+    echo __async_prompt_last_pipestatus
 end
 
 function __async_prompt_config_functions


### PR DESCRIPTION
I use a `postexec` event handler to save the pipestatus. After that, only that saved version of the pipestatus is used.

I tested this on fish 4.0.2 and master.

Fixes #69, #75