### PR TITLE
Discard any output to stderr when building prompt

### DIFF
--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -173,7 +173,7 @@ function __async_prompt_spawn -a cmd
     #   - Runs the command in the background process
     #   - Sends a `SIGUSR1` signal to the parent process when the command is
     #     done
-    echo $vars | env $envs fish -c '
+    echo $vars | env $envs fish -c 'begin
     function __async_prompt_signal
         kill -s "'(__async_prompt_config_internal_signal)'" '$fish_pid' 2>/dev/null
     end
@@ -252,7 +252,8 @@ function __async_prompt_spawn -a cmd
         true
     end
     '$cmd'
-    __async_prompt_signal' 2>/dev/null &
+    __async_prompt_signal
+end 2>&3' 3>&2 2>/dev/null &
 
     # Disowning removes the background process from the shell's list of jobs.
     if test (__async_prompt_config_disown) = 1

--- a/conf.d/__async_prompt.fish
+++ b/conf.d/__async_prompt.fish
@@ -252,7 +252,7 @@ function __async_prompt_spawn -a cmd
         true
     end
     '$cmd'
-    __async_prompt_signal' &
+    __async_prompt_signal' 2>/dev/null &
 
     # Disowning removes the background process from the shell's list of jobs.
     if test (__async_prompt_config_disown) = 1


### PR DESCRIPTION
We got a [report](https://github.com/spinel-coop/rv/issues/236) in rv, that when our shell integration for fish shell is configured, and fish-async-prompt is installed, a spurious `⠁ rubies{}` output is printed after every command.

Since our shell integration runs when `fish` is started, and this library runs `fish` asynchronously to build the prompt, our shell integration gets run. And our shell integration may actually print some diagnosis output to stderr.

I think this kind of output should be discarded? This patch seems to fix the problem for me.